### PR TITLE
Get a nice message for forgotten required options.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,10 +53,13 @@ func newOkta(flags *Flags) *okta.Okta {
 }
 
 func init() {
-	RootCmd.Flags().StringVar(&flags.ClientID, "client-id", "", "OAuth2 client ID of this application.")
-	RootCmd.Flags().StringVar(&flags.ClientSecret, "client-secret", "", "OAuth2 client secret of this application.")
+	RootCmd.Flags().StringVar(&flags.ClientID, "client-id", "", "OAuth2 client ID of this application. (required)")
+	RootCmd.MarkFlagRequired("client-id")
+	RootCmd.Flags().StringVar(&flags.ClientSecret, "client-secret", "", "OAuth2 client secret of this application. (required)")
+	RootCmd.MarkFlagRequired("client-secret")
 
-	RootCmd.PersistentFlags().StringVar(&flags.BaseDomain, "base-domain", "", "URL of the OpenID Connect issuer.")
+	RootCmd.PersistentFlags().StringVar(&flags.BaseDomain, "base-domain", "", "URL of the OpenID Connect issuer. (required)")
+	RootCmd.MarkPersistentFlagRequired("base-domain")
 	RootCmd.PersistentFlags().StringVar(&flags.BindAddr, "bind-addr", "127.0.0.1:8888", "HTTP address to listen at.")
 	RootCmd.PersistentFlags().BoolVar(&flags.Debug, "debug", false, "Raise log level to debug.")
 }


### PR DESCRIPTION
```release-note 
Return nice error message when required flags are not provided
```

```
>go run ./main.go
Error: required flag(s) "base-domain", "client-id", "client-secret" not set
Usage:
  okta-kubectl-auth [flags]

Flags:
      --base-domain string     URL of the OpenID Connect issuer. (required)
      --bind-addr string       HTTP address to listen at. (default "127.0.0.1:8888")
      --client-id string       OAuth2 client ID of this application. (required)
      --client-secret string   OAuth2 client secret of this application. (required)
      --debug                  Raise log level to debug.
  -h, --help                   help for okta-kubectl-auth

required flag(s) "base-domain", "client-id", "client-secret" not set
exit status 1

>
```